### PR TITLE
Host Builder configuration actions

### DIFF
--- a/src/Cortside.AspNetCore/Builder/WebApiBuilder.cs
+++ b/src/Cortside.AspNetCore/Builder/WebApiBuilder.cs
@@ -29,6 +29,19 @@ namespace Cortside.AspNetCore.Builder {
         private bool executingIsEntryAssembly;
         private string url;
 
+        private Action<IHostBuilder> hostConfigurationAction = null;
+        private Action<IWebHostBuilder> webHostConfigurationAction = null;
+
+        public WebApiBuilder WithHostAction(Action<IHostBuilder> action) {
+            this.hostConfigurationAction = action;
+            return this;
+        }
+
+        public WebApiBuilder WithWebHostAction(Action<IWebHostBuilder> action) {
+            this.webHostConfigurationAction = action;
+            return this;
+        }
+
         public WebApiBuilder(string[] args) {
             this.args = args;
         }
@@ -59,6 +72,15 @@ namespace Cortside.AspNetCore.Builder {
             url = System.Environment.GetEnvironmentVariable("ASPNETCORE_URLS");
 
             var builder = WebApplication.CreateBuilder(args);
+
+            if (hostConfigurationAction != null) {
+                hostConfigurationAction(builder.Host);
+            }
+
+            if (webHostConfigurationAction != null) {
+                webHostConfigurationAction(builder.WebHost);
+            }
+
             builder.Host.UseSerilog(Log.Logger);
 
             builder.WebHost.ConfigureAppConfiguration(b => b.AddConfiguration(config));

--- a/src/Cortside.AspNetCore/Builder/WebApiBuilder.cs
+++ b/src/Cortside.AspNetCore/Builder/WebApiBuilder.cs
@@ -32,13 +32,13 @@ namespace Cortside.AspNetCore.Builder {
         private Action<IHostBuilder> hostConfigurationAction = null;
         private Action<IWebHostBuilder> webHostConfigurationAction = null;
 
-        public WebApiBuilder WithHostAction(Action<IHostBuilder> action) {
-            this.hostConfigurationAction = action;
+        public WebApiBuilder WithHostBuilder(Action<IHostBuilder> configuration) {
+            this.hostConfigurationAction = configuration;
             return this;
         }
 
-        public WebApiBuilder WithWebHostAction(Action<IWebHostBuilder> action) {
-            this.webHostConfigurationAction = action;
+        public WebApiBuilder WithWebHostBuilder(Action<IWebHostBuilder> configuration) {
+            this.webHostConfigurationAction = configuration;
             return this;
         }
 


### PR DESCRIPTION
I've encountered the need to apply configuration to the underlying `IWebHostBuilder` and `IHostBuilder` objects, but this framework hides those objects. This is my attempt at solving that by providing a couple of basically-transparent function delegates.