### PR TITLE
Allow configuring Serilog using callable action

### DIFF
--- a/src/Cortside.AspNetCore/Builder/WebApiBuilder.cs
+++ b/src/Cortside.AspNetCore/Builder/WebApiBuilder.cs
@@ -31,6 +31,7 @@ namespace Cortside.AspNetCore.Builder {
 
         private Action<IHostBuilder> hostConfigurationAction = null;
         private Action<IWebHostBuilder> webHostConfigurationAction = null;
+        private Action<LoggerConfiguration> loggerConfigurationAction = null;
 
         public WebApiBuilder WithHostBuilder(Action<IHostBuilder> configuration) {
             this.hostConfigurationAction = configuration;
@@ -39,6 +40,11 @@ namespace Cortside.AspNetCore.Builder {
 
         public WebApiBuilder WithWebHostBuilder(Action<IWebHostBuilder> configuration) {
             this.webHostConfigurationAction = configuration;
+            return this;
+        }
+
+        public WebApiBuilder WithLoggerConfiguration(Action<LoggerConfiguration> configuration) {
+            this.loggerConfigurationAction = configuration;
             return this;
         }
 
@@ -195,6 +201,10 @@ namespace Cortside.AspNetCore.Builder {
             var logFile = config["LogFile:Path"];
             if (!string.IsNullOrWhiteSpace(logFile)) {
                 configuration.WriteTo.File(logFile);
+            }
+
+            if (loggerConfigurationAction != null) {
+                loggerConfigurationAction(configuration);
             }
 
             return configuration;


### PR DESCRIPTION
In the process of integrating Sentry.io into my Cortside app, I ran into the need to directly configure the `LoggingConfiguration` object which is normally wrapped up by the `WebApiBuilder`. 

This allows the end-user to configure the LoggingConfiguration object, similar to the `WithHostBuilder` and `WithWebHostBuilder` methods

Here's how I'm using this:
```csharp
        public static Task<int> Main(string[] args) {
            var builder = WebApiHost.CreateBuilder(args)
                .WithWebHostBuilder(builder => {
                    builder.UseSentry(o => {
                        o.Dsn = "<snip>.ingest.us.sentry.io/<snip>";
                        o.Environment = "dev";
                        o.Debug = true;
                        o.Release = "VeryGroovyService.0.0.1";
                        o.AddEntityFramework();
                        o.CaptureFailedRequests = true;
                        o.SendDefaultPii = true;
                        o.TracesSampleRate = 1.0; // Capture 100% of the application's transactions
                        o.ProfilesSampleRate = 1.0; // profile 100% of the captured transactions
                        o.AddIntegration(new ProfilingIntegration(
                            TimeSpan.FromMilliseconds(500) // wait 500 ms for profiling to start
                        ));
                    });

                })
                .WithLoggerConfiguration(cfg => {
                    cfg.WriteTo.Sentry(s => {
                        s.InitializeSdk = false;
                        s.MinimumBreadcrumbLevel = LogEventLevel.Debug;
                        s.MinimumEventLevel = LogEventLevel.Warning;
                    });
                })
                .UseStartup<Startup>();

            var api = builder.Build();
            return api.StartAsync();
        }
```

The specifics are unimportant here -- but this is how I'm using these methods to configure my Sentry integrations